### PR TITLE
Use latest ubuntu for the workflow env to escape the unsupported v18.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   DBT-DOC-JOB:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2


### PR DESCRIPTION
Use latest ubuntu for the workflow env to escape the unsupported v18.04